### PR TITLE
[feat] 회원가입 기능 구현

### DIFF
--- a/goldblin-auth/build.gradle
+++ b/goldblin-auth/build.gradle
@@ -16,5 +16,8 @@ dependencies {
     // MariaDB
     runtimeOnly 'org.mariadb.jdbc:mariadb-java-client'
 
+    // Test
+    testRuntimeOnly 'com.h2database:h2'
+
     implementation project(':goldblin-common')
 }

--- a/goldblin-auth/build.gradle
+++ b/goldblin-auth/build.gradle
@@ -7,6 +7,9 @@ dependencies {
     implementation "org.springframework.boot:spring-boot-starter-data-jpa"
     implementation 'org.springframework.boot:spring-boot-starter-validation'
 
+    // Argon2
+    implementation 'de.mkammerer:argon2-jvm:2.11'
+
     // MariaDB
     runtimeOnly 'org.mariadb.jdbc:mariadb-java-client'
 

--- a/goldblin-auth/build.gradle
+++ b/goldblin-auth/build.gradle
@@ -4,10 +4,11 @@ jar.enabled = false
 dependencies {
     // Spring Boot
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation "org.springframework.boot:spring-boot-starter-data-jpa"
     implementation 'org.springframework.boot:spring-boot-starter-validation'
 
-    // MySQL
-    runtimeOnly 'com.mysql:mysql-connector-j'
+    // MariaDB
+    runtimeOnly 'org.mariadb.jdbc:mariadb-java-client'
 
     implementation project(':goldblin-common')
 }

--- a/goldblin-auth/build.gradle
+++ b/goldblin-auth/build.gradle
@@ -7,6 +7,9 @@ dependencies {
     implementation "org.springframework.boot:spring-boot-starter-data-jpa"
     implementation 'org.springframework.boot:spring-boot-starter-validation'
 
+    // Swagger
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.3.0'
+
     // Argon2
     implementation 'de.mkammerer:argon2-jvm:2.11'
 

--- a/goldblin-auth/src/main/java/goldblin/auth/business/AuthService.java
+++ b/goldblin-auth/src/main/java/goldblin/auth/business/AuthService.java
@@ -1,0 +1,34 @@
+package goldblin.auth.business;
+
+import static goldblin.auth.constants.AuthMessages.*;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import goldblin.auth.domain.Member;
+import goldblin.auth.domain.service.PasswordManager;
+import goldblin.auth.dto.request.SignUpReq;
+import goldblin.auth.persistence.MemberRepository;
+import jakarta.persistence.EntityExistsException;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class AuthService {
+	private final MemberRepository memberRepository;
+	private final PasswordManager passwordManager;
+
+	@Transactional
+	public Long signup(SignUpReq request) {
+		validateUsernameUnique(request.username());
+		Member member = Member.signup(request.username(), request.password(), passwordManager);
+		return memberRepository.save(member).getId();
+	}
+
+	private void validateUsernameUnique(String username) {
+		if (memberRepository.existsByUsername(username)) {
+			throw new EntityExistsException(DUPLICATE_USERNAME);
+		}
+	}
+}

--- a/goldblin-auth/src/main/java/goldblin/auth/business/AuthService.java
+++ b/goldblin-auth/src/main/java/goldblin/auth/business/AuthService.java
@@ -20,10 +20,12 @@ public class AuthService {
 	private final PasswordManager passwordManager;
 
 	@Transactional
-	public Long signup(SignUpReq request) {
+	public void signup(SignUpReq request) {
 		validateUsernameUnique(request.username());
+
 		Member member = Member.signup(request.username(), request.password(), passwordManager);
-		return memberRepository.save(member).getId();
+
+		memberRepository.save(member);
 	}
 
 	private void validateUsernameUnique(String username) {

--- a/goldblin-auth/src/main/java/goldblin/auth/config/SwaggerConfig.java
+++ b/goldblin-auth/src/main/java/goldblin/auth/config/SwaggerConfig.java
@@ -1,0 +1,24 @@
+package goldblin.auth.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+
+@Configuration
+public class SwaggerConfig {
+
+	@Bean
+	public OpenAPI openAPI() {
+		return new OpenAPI()
+			.info(apiInfo());
+	}
+
+	private Info apiInfo() {
+		return new Info()
+			.title("GOLDBLIN AUTH API")
+			.description("금도깨비 AUTH API 명세서 ✨")
+			.version("v1");
+	}
+}

--- a/goldblin-auth/src/main/java/goldblin/auth/constants/AuthMessages.java
+++ b/goldblin-auth/src/main/java/goldblin/auth/constants/AuthMessages.java
@@ -5,6 +5,10 @@ import lombok.NoArgsConstructor;
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public final class AuthMessages {
+	/**
+	 * 200 번대 성공 메시지
+	 */
+	public static final String SIGNUP_SUCCESS = "회원가입이 완료되었습니다.";
 
 	/**
 	 * 400 번대 에러 메시지

--- a/goldblin-auth/src/main/java/goldblin/auth/constants/AuthMessages.java
+++ b/goldblin-auth/src/main/java/goldblin/auth/constants/AuthMessages.java
@@ -1,6 +1,10 @@
 package goldblin.auth.constants;
 
-public class AuthMessages {
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class AuthMessages {
 
 	/**
 	 * 400 번대 에러 메시지

--- a/goldblin-auth/src/main/java/goldblin/auth/constants/AuthMessages.java
+++ b/goldblin-auth/src/main/java/goldblin/auth/constants/AuthMessages.java
@@ -1,0 +1,14 @@
+package goldblin.auth.constants;
+
+public class AuthMessages {
+
+	/**
+	 * 400 번대 에러 메시지
+	 */
+	public static final String SHORT_PASSWORD = "비밀번호는 8자 이상이어야 합니다.";
+	public static final String INVALID_PASSWORD_FORMAT = "비밀번호는 영문, 숫자, 특수문자를 모두 포함해야 합니다.";
+	public static final String BLANK_USERNAME = "아이디는 필수값입니다.";
+	public static final String TOO_LONG_USERNAME = "아이디는 50자 이하여야 합니다.";
+	public static final String BLANK_PASSWORD = "비밀번호는 필수값입니다.";
+	public static final String DUPLICATE_USERNAME = "이미 사용중인 아이디입니다.";
+}

--- a/goldblin-auth/src/main/java/goldblin/auth/domain/Member.java
+++ b/goldblin-auth/src/main/java/goldblin/auth/domain/Member.java
@@ -1,0 +1,53 @@
+package goldblin.auth.domain;
+
+import goldblin.auth.domain.enums.AuthType;
+import goldblin.auth.domain.service.PasswordManager;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "member")
+@Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Member {
+	public static final AuthType DEFAULT_AUTH_TYPE = AuthType.ROLE_USER;
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "id")
+	private Long id;
+
+	@Enumerated(value = EnumType.STRING)
+	@Column(name = "authority", nullable = false, columnDefinition = "VARCHAR(20)")
+	private AuthType authorityType;
+
+	@Column(name = "username", unique = true, nullable = false, length = 50)
+	private String username;
+
+	@Column(name = "password", nullable = false)
+	private String encryptedPassword;
+
+	@Column(name = "refresh_token")
+	private String refreshToken;
+
+	public static Member signup(String username, String password, PasswordManager passwordManager) {
+		return Member.builder()
+			.authorityType(DEFAULT_AUTH_TYPE)
+			.username(username)
+			.encryptedPassword(passwordManager.encrypt(password))
+			.build();
+	}
+}

--- a/goldblin-auth/src/main/java/goldblin/auth/domain/enums/AuthType.java
+++ b/goldblin-auth/src/main/java/goldblin/auth/domain/enums/AuthType.java
@@ -1,0 +1,5 @@
+package goldblin.auth.domain.enums;
+
+public enum AuthType {
+	ROLE_USER, ROLE_ADMIN
+}

--- a/goldblin-auth/src/main/java/goldblin/auth/domain/service/PasswordEncoder.java
+++ b/goldblin-auth/src/main/java/goldblin/auth/domain/service/PasswordEncoder.java
@@ -1,0 +1,7 @@
+package goldblin.auth.domain.service;
+
+public interface PasswordEncoder {
+	String encode(String rawPassword);
+
+	boolean matches(String rawPassword, String encodedPassword);
+}

--- a/goldblin-auth/src/main/java/goldblin/auth/domain/service/PasswordManager.java
+++ b/goldblin-auth/src/main/java/goldblin/auth/domain/service/PasswordManager.java
@@ -1,0 +1,55 @@
+package goldblin.auth.domain.service;
+
+import static goldblin.auth.constants.AuthMessages.*;
+
+import java.util.regex.Pattern;
+
+import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class PasswordManager {
+	private static final int MIN_PASSWORD_LENGTH = 8;
+	private static final Pattern PASSWORD_PATTERN = Pattern.compile(
+		"^(?=.*[A-Za-z])(?=.*\\d)(?=.*[$@!%*#?&^])[A-Za-z\\d$@!%*#?&^]+$");
+
+	private final PasswordEncoder passwordEncoder;
+
+	public String encrypt(String rawPassword) {
+		validate(rawPassword);
+		return passwordEncoder.encode(rawPassword);
+	}
+
+	public boolean matches(String rawPassword, String encryptedPassword) {
+		return passwordEncoder.matches(rawPassword, encryptedPassword);
+	}
+
+	private void validate(String rawPassword) {
+		validateLength(rawPassword);
+		validateFormat(rawPassword);
+	}
+
+	private void validateLength(String rawPassword) {
+		// 조건 1. 비밀번호는 8자 이상이어야 합니다.
+		if (isShort(rawPassword)) {
+			throw new IllegalArgumentException(SHORT_PASSWORD);
+		}
+	}
+
+	private void validateFormat(String rawPassword) {
+		// 조건 2. 비밀번호는 영문, 숫자, 특수문자를 모두 포함해야 합니다.
+		if (isNotMatched(rawPassword)) {
+			throw new IllegalArgumentException(INVALID_PASSWORD_FORMAT);
+		}
+	}
+
+	private boolean isShort(String plainPassword) {
+		return plainPassword.length() < MIN_PASSWORD_LENGTH;
+	}
+
+	private boolean isNotMatched(String plainPassword) {
+		return !PASSWORD_PATTERN.matcher(plainPassword).matches();
+	}
+}

--- a/goldblin-auth/src/main/java/goldblin/auth/dto/request/SignUpReq.java
+++ b/goldblin-auth/src/main/java/goldblin/auth/dto/request/SignUpReq.java
@@ -1,0 +1,15 @@
+package goldblin.auth.dto.request;
+
+import static goldblin.auth.constants.AuthMessages.*;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record SignUpReq(
+	@NotBlank(message = BLANK_USERNAME)
+	@Size(max = 50, message = TOO_LONG_USERNAME)
+	String username,
+	@NotBlank(message = BLANK_PASSWORD)
+	String password
+) {
+}

--- a/goldblin-auth/src/main/java/goldblin/auth/dto/request/SignUpReq.java
+++ b/goldblin-auth/src/main/java/goldblin/auth/dto/request/SignUpReq.java
@@ -2,14 +2,18 @@ package goldblin.auth.dto.request;
 
 import static goldblin.auth.constants.AuthMessages.*;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 
+@Schema(description = "회원가입 요청 정보")
 public record SignUpReq(
 	@NotBlank(message = BLANK_USERNAME)
 	@Size(max = 50, message = TOO_LONG_USERNAME)
+	@Schema(description = "아이디", example = "goldblin")
 	String username,
 	@NotBlank(message = BLANK_PASSWORD)
+	@Schema(description = "비밀번호 (숫자, 영문자, 특수문자를 포함한 8자리 이상의 문자열)", example = "password12!")
 	String password
 ) {
 }

--- a/goldblin-auth/src/main/java/goldblin/auth/infrastructure/encryption/Argon2PasswordEncoder.java
+++ b/goldblin-auth/src/main/java/goldblin/auth/infrastructure/encryption/Argon2PasswordEncoder.java
@@ -1,0 +1,30 @@
+package goldblin.auth.infrastructure.encryption;
+
+import org.springframework.stereotype.Component;
+
+import de.mkammerer.argon2.Argon2;
+import de.mkammerer.argon2.Argon2Factory;
+import goldblin.auth.domain.service.PasswordEncoder;
+
+@Component
+public class Argon2PasswordEncoder implements PasswordEncoder {
+	private static final int DEFAULT_ITERATIONS = 3; // 해싱 횟수 (브루트 포스 공격 방지)
+	private static final int DEFAULT_MEMORY = 65536; // 기본 메모리 사용량 (64MB)
+	private static final int DEFAULT_PARALLELISM = 1; // 기본 병렬 처리 정도
+
+	private final Argon2 argon2;
+
+	public Argon2PasswordEncoder() {
+		this.argon2 = Argon2Factory.create();
+	}
+
+	@Override
+	public String encode(String rawPassword) {
+		return argon2.hash(DEFAULT_ITERATIONS, DEFAULT_MEMORY, DEFAULT_PARALLELISM, rawPassword.toCharArray());
+	}
+
+	@Override
+	public boolean matches(String rawPassword, String encodedPassword) {
+		return argon2.verify(encodedPassword, rawPassword.toCharArray());
+	}
+}

--- a/goldblin-auth/src/main/java/goldblin/auth/persistence/MemberRepository.java
+++ b/goldblin-auth/src/main/java/goldblin/auth/persistence/MemberRepository.java
@@ -1,0 +1,9 @@
+package goldblin.auth.persistence;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import goldblin.auth.domain.Member;
+
+public interface MemberRepository extends JpaRepository<Member, Long> {
+	boolean existsByUsername(String username);
+}

--- a/goldblin-auth/src/main/java/goldblin/auth/presentation/api/AuthApiController.java
+++ b/goldblin-auth/src/main/java/goldblin/auth/presentation/api/AuthApiController.java
@@ -11,6 +11,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import goldblin.auth.business.AuthService;
 import goldblin.auth.dto.request.SignUpReq;
+import goldblin.auth.presentation.docs.AuthApiControllerDoc;
 import goldblin.common.api.ApiResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -18,7 +19,7 @@ import lombok.RequiredArgsConstructor;
 @RestController
 @RequestMapping("/api/auth")
 @RequiredArgsConstructor
-public class AuthApiController {
+public class AuthApiController implements AuthApiControllerDoc {
 	private final AuthService authService;
 
 	@PostMapping("/signup")

--- a/goldblin-auth/src/main/java/goldblin/auth/presentation/api/AuthApiController.java
+++ b/goldblin-auth/src/main/java/goldblin/auth/presentation/api/AuthApiController.java
@@ -1,0 +1,31 @@
+package goldblin.auth.presentation.api;
+
+import java.net.URI;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import goldblin.auth.business.AuthService;
+import goldblin.auth.dto.request.SignUpReq;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api/auth")
+@RequiredArgsConstructor
+public class AuthApiController {
+	private final AuthService authService;
+
+	@PostMapping("/signup")
+	public ResponseEntity<Void> signup(@RequestBody @Valid SignUpReq request) {
+		Long resourceId = authService.signup(request);
+		URI location = URI.create("/api/member/" + resourceId);
+
+		return ResponseEntity.created(location)
+			.build();
+	}
+
+}

--- a/goldblin-auth/src/main/java/goldblin/auth/presentation/api/AuthApiController.java
+++ b/goldblin-auth/src/main/java/goldblin/auth/presentation/api/AuthApiController.java
@@ -1,15 +1,17 @@
 package goldblin.auth.presentation.api;
 
-import java.net.URI;
+import static goldblin.auth.constants.AuthMessages.*;
+import static org.springframework.http.HttpStatus.*;
 
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 import goldblin.auth.business.AuthService;
 import goldblin.auth.dto.request.SignUpReq;
+import goldblin.common.api.ApiResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
@@ -20,12 +22,10 @@ public class AuthApiController {
 	private final AuthService authService;
 
 	@PostMapping("/signup")
-	public ResponseEntity<Void> signup(@RequestBody @Valid SignUpReq request) {
-		Long resourceId = authService.signup(request);
-		URI location = URI.create("/api/member/" + resourceId);
-
-		return ResponseEntity.created(location)
-			.build();
+	@ResponseStatus(CREATED)
+	public ApiResponse<Void> signup(@RequestBody @Valid SignUpReq request) {
+		authService.signup(request);
+		return ApiResponse.of(CREATED, SIGNUP_SUCCESS, null);
 	}
 
 }

--- a/goldblin-auth/src/main/java/goldblin/auth/presentation/docs/AuthApiControllerDoc.java
+++ b/goldblin-auth/src/main/java/goldblin/auth/presentation/docs/AuthApiControllerDoc.java
@@ -1,0 +1,13 @@
+package goldblin.auth.presentation.docs;
+
+import goldblin.auth.dto.request.SignUpReq;
+import goldblin.common.api.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@Tag(name = "Auth", description = "회원 인증 API")
+public interface AuthApiControllerDoc {
+
+	@Operation(summary = "회원가입")
+	ApiResponse<Void> signup(SignUpReq request);
+}

--- a/goldblin-auth/src/main/java/goldblin/auth/presentation/exception/GlobalExceptionHandler.java
+++ b/goldblin-auth/src/main/java/goldblin/auth/presentation/exception/GlobalExceptionHandler.java
@@ -1,0 +1,77 @@
+package goldblin.auth.presentation.exception;
+
+import static org.springframework.http.HttpStatus.*;
+
+import org.springframework.context.support.DefaultMessageSourceResolvable;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import goldblin.common.api.ApiResponse;
+import jakarta.persistence.EntityExistsException;
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@RestControllerAdvice
+@RequiredArgsConstructor
+@Slf4j
+public class GlobalExceptionHandler {
+
+	/**
+	 * 4XX 에러 처리
+	 */
+	@ResponseStatus(BAD_REQUEST)
+	@ExceptionHandler(MethodArgumentNotValidException.class)
+	public ApiResponse<Void> handleMethodArgumentNotValidException(MethodArgumentNotValidException e) {
+		log.debug(e.getMessage(), e.fillInStackTrace());
+
+		return ApiResponse.error(BAD_REQUEST, extractErrorMessages(e));
+	}
+
+	@ResponseStatus(BAD_REQUEST)
+	@ExceptionHandler(IllegalArgumentException.class)
+	public ApiResponse<Void> handleIllegalArgumentException(IllegalArgumentException e) {
+		log.debug(e.getMessage(), e.fillInStackTrace());
+
+		return ApiResponse.error(BAD_REQUEST, e.getMessage());
+	}
+
+	@ResponseStatus(NOT_FOUND)
+	@ExceptionHandler(EntityNotFoundException.class)
+	public ApiResponse<Void> handleEntityNotFoundException(EntityNotFoundException e) {
+		log.debug(e.getMessage(), e.fillInStackTrace());
+
+		return ApiResponse.error(NOT_FOUND, e.getMessage());
+	}
+
+	@ResponseStatus(CONFLICT)
+	@ExceptionHandler(EntityExistsException.class)
+	public ApiResponse<Void> handleEntityExistsException(EntityExistsException e) {
+		log.debug(e.getMessage(), e.fillInStackTrace());
+
+		return ApiResponse.error(CONFLICT, e.getMessage());
+	}
+
+	/**
+	 * 5XX 에러 처리
+	 */
+	@ResponseStatus(INTERNAL_SERVER_ERROR)
+	@ExceptionHandler(Exception.class)
+	public ApiResponse<Void> handleException(Exception e) {
+		log.error(e.getMessage(), e.fillInStackTrace());
+
+		return ApiResponse.error(HttpStatus.INTERNAL_SERVER_ERROR, e.getMessage());
+	}
+
+	private String extractErrorMessages(MethodArgumentNotValidException e) {
+		return e.getBindingResult()
+			.getAllErrors()
+			.stream()
+			.map(DefaultMessageSourceResolvable::getDefaultMessage)
+			.toList()
+			.toString();
+	}
+}

--- a/goldblin-auth/src/main/resources/application-example.yml
+++ b/goldblin-auth/src/main/resources/application-example.yml
@@ -9,3 +9,10 @@ spring:
     open-in-view: false
     hibernate:
       ddl-auto: validate
+
+springdoc:
+  default-consumes-media-type: application/json
+  default-produces-media-type: application/json
+  swagger-ui:
+    tags-sorter: alpha
+    operations-sorter: method

--- a/goldblin-auth/src/main/resources/application-example.yml
+++ b/goldblin-auth/src/main/resources/application-example.yml
@@ -1,3 +1,6 @@
+server:
+  port: 8888
+
 spring:
   datasource:
     driver-class-name: org.mariadb.jdbc.Driver

--- a/goldblin-auth/src/main/resources/application-example.yml
+++ b/goldblin-auth/src/main/resources/application-example.yml
@@ -1,0 +1,11 @@
+spring:
+  datasource:
+    driver-class-name: org.mariadb.jdbc.Driver
+    url: ${DATABASE_URL}
+    username: ${DATABASE_USER}
+    password: ${DATABASE_PASSWORD}
+
+  jpa:
+    open-in-view: false
+    hibernate:
+      ddl-auto: validate

--- a/goldblin-auth/src/test/resources/application.yml
+++ b/goldblin-auth/src/test/resources/application.yml
@@ -1,0 +1,10 @@
+spring:
+  datasource:
+    url: jdbc:h2:mem:testdb;MODE=MARIADB;DB_CLOSE_ON_EXIT=FALSE
+    username: sa
+    driver-class-name: org.h2.Driver
+
+  jpa:
+    show-sql: true
+    hibernate:
+      ddl-auto: create-drop

--- a/goldblin-common/build.gradle
+++ b/goldblin-common/build.gradle
@@ -1,2 +1,10 @@
 bootJar.enabled = false
 jar.enabled = true
+
+dependencies {
+    // Spring Boot
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+
+    // Swagger
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.3.0'
+}

--- a/goldblin-common/src/main/java/goldblin/common/api/ApiResponse.java
+++ b/goldblin-common/src/main/java/goldblin/common/api/ApiResponse.java
@@ -4,13 +4,22 @@ import static org.springframework.http.HttpStatus.*;
 
 import org.springframework.http.HttpStatus;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 
 @Getter
+@Schema(description = "API 응답")
 public class ApiResponse<T> {
+	@Schema(description = "상태 코드", example = "200")
 	private int code;
+
+	@Schema(description = "상태", example = "OK")
 	private HttpStatus status;
+
+	@Schema(description = "메시지", example = "요청하신 작업을 완료했습니다.")
 	private String message;
+
+	@Schema(description = "응답 데이터")
 	private T data;
 
 	private ApiResponse(HttpStatus status, String message, T data) {

--- a/goldblin-common/src/main/java/goldblin/common/api/ApiResponse.java
+++ b/goldblin-common/src/main/java/goldblin/common/api/ApiResponse.java
@@ -1,0 +1,38 @@
+package goldblin.common.api;
+
+import static org.springframework.http.HttpStatus.*;
+
+import org.springframework.http.HttpStatus;
+
+import lombok.Getter;
+
+@Getter
+public class ApiResponse<T> {
+	private int code;
+	private HttpStatus status;
+	private String message;
+	private T data;
+
+	private ApiResponse(HttpStatus status, String message, T data) {
+		this.code = status.value();
+		this.status = status;
+		this.message = message;
+		this.data = data;
+	}
+
+	public static <T> ApiResponse<T> of(HttpStatus httpStatus, String message, T data) {
+		return new ApiResponse<>(httpStatus, message, data);
+	}
+
+	public static <T> ApiResponse<T> of(HttpStatus httpStatus, T data) {
+		return of(httpStatus, httpStatus.name(), data);
+	}
+
+	public static <T> ApiResponse<T> ok(T data) {
+		return of(OK, data);
+	}
+
+	public static <T> ApiResponse<T> error(HttpStatus httpStatus, String message) {
+		return new ApiResponse<>(httpStatus, message, null);
+	}
+}

--- a/goldblin-order/build.gradle
+++ b/goldblin-order/build.gradle
@@ -12,8 +12,8 @@ dependencies {
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 
-    // MySQL
-    runtimeOnly 'com.mysql:mysql-connector-j'
+    // MariaDB
+    runtimeOnly 'org.mariadb.jdbc:mariadb-java-client'
 
     implementation project(':goldblin-common')
 }


### PR DESCRIPTION
## 📎 관련 이슈
<!--이슈 태스크를 모두 완료하고 닫는다면 Resolves #번호-->
<!--이슈 태스크를 모두 완료하지는 못 했지만 닫는다면 Closes #번호-->
<!--이슈 태스크를 일부 완료하고 열어둔다면 Fixes #번호-->
Resolves #3 

## 📌 구현 내용
<!--빠른 리뷰를 위해 이해를 도울 만한 설명이 있다면 적어주세요!-->
- [x] 회원가입 비즈니스 로직 구현
- [x] 전역 예외 처리 설정
- [x] 스웨거 설정 

## 📝 고민한 점
- `ApiResponse`를 통한 일관성있는 응답 형식
- 유연한 비밀번호 암호화 알고리즘 변경을 위한 Interface 도입
- Member 도메인 객체에서 비밀번호 관련 로직을 분리하기 위해 `PasswordManager` 도메인 서비스 도입
