### PR TITLE
[feat] 로그인 기능 구현

### DIFF
--- a/goldblin-auth/build.gradle
+++ b/goldblin-auth/build.gradle
@@ -16,6 +16,11 @@ dependencies {
     // MariaDB
     runtimeOnly 'org.mariadb.jdbc:mariadb-java-client'
 
+    // Jjwt
+    implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+
     // Test
     testRuntimeOnly 'com.h2database:h2'
 

--- a/goldblin-auth/src/main/java/goldblin/auth/GoldblinAuthApplication.java
+++ b/goldblin-auth/src/main/java/goldblin/auth/GoldblinAuthApplication.java
@@ -2,10 +2,12 @@ package goldblin.auth;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 
 @SpringBootApplication
+@ConfigurationPropertiesScan
 public class GoldblinAuthApplication {
-	
+
 	public static void main(String[] args) {
 		SpringApplication.run(GoldblinAuthApplication.class, args);
 	}

--- a/goldblin-auth/src/main/java/goldblin/auth/business/AuthService.java
+++ b/goldblin-auth/src/main/java/goldblin/auth/business/AuthService.java
@@ -6,10 +6,16 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import goldblin.auth.domain.Member;
+import goldblin.auth.domain.RefreshToken;
+import goldblin.auth.domain.service.JwtManager;
 import goldblin.auth.domain.service.PasswordManager;
+import goldblin.auth.dto.request.LoginReq;
 import goldblin.auth.dto.request.SignUpReq;
+import goldblin.auth.dto.response.LoginRes;
 import goldblin.auth.infrastructure.persistence.MemberRepository;
+import goldblin.auth.infrastructure.persistence.RefreshTokenRepository;
 import jakarta.persistence.EntityExistsException;
+import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 
 @Service
@@ -17,7 +23,9 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class AuthService {
 	private final MemberRepository memberRepository;
+	private final RefreshTokenRepository refreshTokenRepository;
 	private final PasswordManager passwordManager;
+	private final JwtManager jwtManager;
 
 	@Transactional
 	public void signup(SignUpReq request) {
@@ -28,9 +36,35 @@ public class AuthService {
 		memberRepository.save(member);
 	}
 
+	@Transactional
+	public LoginRes login(LoginReq request) {
+		Member member = memberRepository.findByUsername(request.username())
+			.orElseThrow(() -> new EntityNotFoundException(INVALID_USERNAME));
+
+		validateCredential(member, request.password());
+
+		String accessToken = jwtManager.generateAccessToken(member);
+		String refreshToken = jwtManager.generateRefreshToken(member);
+
+		saveRefreshToken(member, refreshToken);
+
+		return LoginRes.of(accessToken, refreshToken);
+	}
+
+	private void saveRefreshToken(Member member, String refreshToken) {
+		RefreshToken token = RefreshToken.of(member, refreshToken, jwtManager);
+		refreshTokenRepository.save(token);
+	}
+
 	private void validateUsernameUnique(String username) {
 		if (memberRepository.existsByUsername(username)) {
 			throw new EntityExistsException(DUPLICATE_USERNAME);
+		}
+	}
+
+	private void validateCredential(Member member, String password) {
+		if (!passwordManager.matches(password, member.getEncryptedPassword())) {
+			throw new IllegalArgumentException(INVALID_PASSWORD);
 		}
 	}
 }

--- a/goldblin-auth/src/main/java/goldblin/auth/business/AuthService.java
+++ b/goldblin-auth/src/main/java/goldblin/auth/business/AuthService.java
@@ -8,7 +8,7 @@ import org.springframework.transaction.annotation.Transactional;
 import goldblin.auth.domain.Member;
 import goldblin.auth.domain.service.PasswordManager;
 import goldblin.auth.dto.request.SignUpReq;
-import goldblin.auth.persistence.MemberRepository;
+import goldblin.auth.infrastructure.persistence.MemberRepository;
 import jakarta.persistence.EntityExistsException;
 import lombok.RequiredArgsConstructor;
 

--- a/goldblin-auth/src/main/java/goldblin/auth/config/properties/JwtProperties.java
+++ b/goldblin-auth/src/main/java/goldblin/auth/config/properties/JwtProperties.java
@@ -1,0 +1,13 @@
+package goldblin.auth.config.properties;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties("jwt")
+public record JwtProperties(
+	String issuer,
+	String secretKey,
+	int expiredAfter,
+	int refreshExpiredAfter
+) {
+
+}

--- a/goldblin-auth/src/main/java/goldblin/auth/constants/AuthMessages.java
+++ b/goldblin-auth/src/main/java/goldblin/auth/constants/AuthMessages.java
@@ -19,4 +19,8 @@ public final class AuthMessages {
 	public static final String TOO_LONG_USERNAME = "아이디는 50자 이하여야 합니다.";
 	public static final String BLANK_PASSWORD = "비밀번호는 필수값입니다.";
 	public static final String DUPLICATE_USERNAME = "이미 사용중인 아이디입니다.";
+	public static final String INVALID_USERNAME = "해당 아이디를 가진 사용자가 존재하지 않습니다.";
+	public static final String INVALID_PASSWORD = "비밀번호가 올바르지 않습니다.";
+	public static final String EXPIRED_TOKEN = "만료된 토큰입니다.";
+	public static final String INVALID_TOKEN = "유효하지 않은 토큰입니다.";
 }

--- a/goldblin-auth/src/main/java/goldblin/auth/domain/Member.java
+++ b/goldblin-auth/src/main/java/goldblin/auth/domain/Member.java
@@ -40,9 +40,6 @@ public class Member {
 	@Column(name = "password", nullable = false)
 	private String encryptedPassword;
 
-	@Column(name = "refresh_token")
-	private String refreshToken;
-
 	public static Member signup(String username, String password, PasswordManager passwordManager) {
 		return Member.builder()
 			.authorityType(DEFAULT_AUTH_TYPE)

--- a/goldblin-auth/src/main/java/goldblin/auth/domain/RefreshToken.java
+++ b/goldblin-auth/src/main/java/goldblin/auth/domain/RefreshToken.java
@@ -1,0 +1,50 @@
+package goldblin.auth.domain;
+
+import java.time.LocalDateTime;
+
+import goldblin.auth.domain.service.JwtManager;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "refresh_token")
+@Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class RefreshToken {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "id")
+	private Long id;
+
+	@OneToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "member_id", nullable = false)
+	private Member member;
+
+	@Column(name = "value", nullable = false)
+	private String token;
+
+	@Column(name = "expired_at", nullable = false, columnDefinition = "TIMESTAMP")
+	private LocalDateTime expiredAt;
+
+	public static RefreshToken of(Member member, String token, JwtManager jwtManager) {
+		return RefreshToken.builder()
+			.member(member)
+			.token(token)
+			.expiredAt(jwtManager.getExpiredAt(token))
+			.build();
+	}
+}

--- a/goldblin-auth/src/main/java/goldblin/auth/domain/service/JwtManager.java
+++ b/goldblin-auth/src/main/java/goldblin/auth/domain/service/JwtManager.java
@@ -1,0 +1,90 @@
+package goldblin.auth.domain.service;
+
+import static goldblin.auth.constants.AuthMessages.*;
+
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.Date;
+
+import javax.crypto.SecretKey;
+
+import org.springframework.stereotype.Component;
+
+import goldblin.auth.config.properties.JwtProperties;
+import goldblin.auth.domain.Member;
+import goldblin.auth.domain.enums.AuthType;
+import goldblin.auth.exception.TokenValidationFailException;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+
+@Component
+public class JwtManager {
+	private static final long MILLISECONDS_PER_MINUTE = 60 * 1000L;
+	public static final String MEMBER_ID_CLAIM = "memberId";
+	public static final String ROLE_CLAIM = "role";
+
+	private final String issuer;
+	private final SecretKey secretKey;
+	private final long expiredAfter;
+	private final long refreshExpiredAfter;
+
+	public JwtManager(JwtProperties jwtProperties) {
+		issuer = jwtProperties.issuer();
+		secretKey = Keys.hmacShaKeyFor(jwtProperties.secretKey().getBytes(StandardCharsets.UTF_8));
+		expiredAfter = jwtProperties.expiredAfter() * MILLISECONDS_PER_MINUTE;
+		refreshExpiredAfter = jwtProperties.refreshExpiredAfter() * MILLISECONDS_PER_MINUTE;
+	}
+
+	public String generateAccessToken(Member member) {
+		return generateToken(member, expiredAfter);
+	}
+
+	public String generateRefreshToken(Member member) {
+		return generateToken(member, refreshExpiredAfter);
+	}
+
+	public Long getMemberId(String token) {
+		return parseClaims(token).get(MEMBER_ID_CLAIM, Long.class);
+	}
+
+	public AuthType getRole(String token) {
+		return AuthType.valueOf(parseClaims(token).get(ROLE_CLAIM, String.class));
+	}
+
+	public LocalDateTime getExpiredAt(String token) {
+		Date expirationDate = parseClaims(token).getExpiration();
+		return LocalDateTime.ofInstant(expirationDate.toInstant(), ZoneId.systemDefault());
+	}
+
+	private String generateToken(Member member, long expiredAfter) {
+		Instant now = Instant.now();
+		Instant expiredAt = now.plusMillis(expiredAfter);
+
+		return Jwts.builder()
+			.setIssuer(issuer)
+			.setIssuedAt(Date.from(now))
+			.setExpiration(Date.from(expiredAt))
+			.claim(MEMBER_ID_CLAIM, member.getId())
+			.claim(ROLE_CLAIM, member.getAuthorityType())
+			.signWith(secretKey)
+			.compact();
+	}
+
+	private Claims parseClaims(String token) {
+		try {
+			return Jwts.parserBuilder()
+				.setSigningKey(secretKey)
+				.build()
+				.parseClaimsJws(token)
+				.getBody();
+		} catch (ExpiredJwtException e) {
+			throw new TokenValidationFailException(EXPIRED_TOKEN);
+		} catch (Exception e) {
+			throw new TokenValidationFailException(INVALID_TOKEN);
+		}
+	}
+}

--- a/goldblin-auth/src/main/java/goldblin/auth/dto/request/LoginReq.java
+++ b/goldblin-auth/src/main/java/goldblin/auth/dto/request/LoginReq.java
@@ -1,0 +1,17 @@
+package goldblin.auth.dto.request;
+
+import static goldblin.auth.constants.AuthMessages.*;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+
+@Schema(description = "로그인 요청 정보")
+public record LoginReq(
+	@NotBlank(message = BLANK_USERNAME)
+	@Schema(description = "아이디", example = "goldblin")
+	String username,
+	@NotBlank(message = BLANK_PASSWORD)
+	@Schema(description = "비밀번호", example = "password12!")
+	String password
+) {
+}

--- a/goldblin-auth/src/main/java/goldblin/auth/dto/response/LoginRes.java
+++ b/goldblin-auth/src/main/java/goldblin/auth/dto/response/LoginRes.java
@@ -1,0 +1,15 @@
+package goldblin.auth.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "로그인 응답 정보")
+public record LoginRes(
+	@Schema(description = "액세스 토큰", example = "eyJhbGciOiJIUzUxMiJ9.eyJpc3MiOiJnb2xkYmxpbiIsImlhdCI6MTcyNTgxMzEzMCwiZXhwIjoxNzI1ODE2NzMwLCJtZW1iZXJJZCI6MSwicm9sZSI6IlJPTEVfVVNFUiJ9.FHJZGZfvGWGILKl0IiI3kuD_djyxRGKgG5c38SkzuNiocty8H0jZ4Noww_Eji0HmCkVtq0R7UG8mrzHYCKaUOQ")
+	String accessToken,
+	@Schema(description = "리프레시 토큰", example = "eyJhbGciOiJIUzUxMiJ9.eyJpc3MiOiJnb2xkYmxpbiIsImlhdCI6MTcyNTgxMzEzMCwiZXhwIjoxNzI1ODE2NzMwLCJtZW1iZXJJZCI6MSwicm9sZSI6IlJPTEVfVVNFUiJ9.FHJZGZfvGWGILKl0IiI3kuD_djyxRGKgG5c38SkzuNiocty8H0jZ4Noww_Eji0HmCkVtq0R7UG8mrzHYCKaUOQ")
+	String refreshToken
+) {
+	public static LoginRes of(String accessToken, String refreshToken) {
+		return new LoginRes(accessToken, refreshToken);
+	}
+}

--- a/goldblin-auth/src/main/java/goldblin/auth/exception/TokenValidationFailException.java
+++ b/goldblin-auth/src/main/java/goldblin/auth/exception/TokenValidationFailException.java
@@ -1,0 +1,9 @@
+package goldblin.auth.exception;
+
+public class TokenValidationFailException extends RuntimeException {
+
+	public TokenValidationFailException(String message) {
+		super(message);
+	}
+
+}

--- a/goldblin-auth/src/main/java/goldblin/auth/infrastructure/persistence/MemberRepository.java
+++ b/goldblin-auth/src/main/java/goldblin/auth/infrastructure/persistence/MemberRepository.java
@@ -1,4 +1,4 @@
-package goldblin.auth.persistence;
+package goldblin.auth.infrastructure.persistence;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 

--- a/goldblin-auth/src/main/java/goldblin/auth/infrastructure/persistence/MemberRepository.java
+++ b/goldblin-auth/src/main/java/goldblin/auth/infrastructure/persistence/MemberRepository.java
@@ -1,9 +1,13 @@
 package goldblin.auth.infrastructure.persistence;
 
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import goldblin.auth.domain.Member;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
 	boolean existsByUsername(String username);
+
+	Optional<Member> findByUsername(String username);
 }

--- a/goldblin-auth/src/main/java/goldblin/auth/infrastructure/persistence/RefreshTokenRepository.java
+++ b/goldblin-auth/src/main/java/goldblin/auth/infrastructure/persistence/RefreshTokenRepository.java
@@ -1,0 +1,8 @@
+package goldblin.auth.infrastructure.persistence;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import goldblin.auth.domain.RefreshToken;
+
+public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
+}

--- a/goldblin-auth/src/main/java/goldblin/auth/presentation/api/AuthApiController.java
+++ b/goldblin-auth/src/main/java/goldblin/auth/presentation/api/AuthApiController.java
@@ -10,7 +10,9 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 import goldblin.auth.business.AuthService;
+import goldblin.auth.dto.request.LoginReq;
 import goldblin.auth.dto.request.SignUpReq;
+import goldblin.auth.dto.response.LoginRes;
 import goldblin.auth.presentation.docs.AuthApiControllerDoc;
 import goldblin.common.api.ApiResponse;
 import jakarta.validation.Valid;
@@ -27,6 +29,13 @@ public class AuthApiController implements AuthApiControllerDoc {
 	public ApiResponse<Void> signup(@RequestBody @Valid SignUpReq request) {
 		authService.signup(request);
 		return ApiResponse.of(CREATED, SIGNUP_SUCCESS, null);
+	}
+
+	@PostMapping("/lonin")
+	@ResponseStatus(OK)
+	public ApiResponse<LoginRes> login(@RequestBody @Valid LoginReq request) {
+		LoginRes response = authService.login(request);
+		return ApiResponse.ok(response);
 	}
 
 }

--- a/goldblin-auth/src/main/java/goldblin/auth/presentation/docs/AuthApiControllerDoc.java
+++ b/goldblin-auth/src/main/java/goldblin/auth/presentation/docs/AuthApiControllerDoc.java
@@ -1,6 +1,8 @@
 package goldblin.auth.presentation.docs;
 
+import goldblin.auth.dto.request.LoginReq;
 import goldblin.auth.dto.request.SignUpReq;
+import goldblin.auth.dto.response.LoginRes;
 import goldblin.common.api.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -10,4 +12,7 @@ public interface AuthApiControllerDoc {
 
 	@Operation(summary = "회원가입")
 	ApiResponse<Void> signup(SignUpReq request);
+
+	@Operation(summary = "로그인")
+	ApiResponse<LoginRes> login(LoginReq request);
 }

--- a/goldblin-auth/src/main/java/goldblin/auth/presentation/exception/GlobalExceptionHandler.java
+++ b/goldblin-auth/src/main/java/goldblin/auth/presentation/exception/GlobalExceptionHandler.java
@@ -9,6 +9,7 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
+import goldblin.auth.exception.TokenValidationFailException;
 import goldblin.common.api.ApiResponse;
 import jakarta.persistence.EntityExistsException;
 import jakarta.persistence.EntityNotFoundException;
@@ -37,6 +38,14 @@ public class GlobalExceptionHandler {
 		log.debug(e.getMessage(), e.fillInStackTrace());
 
 		return ApiResponse.error(BAD_REQUEST, e.getMessage());
+	}
+
+	@ResponseStatus(UNAUTHORIZED)
+	@ExceptionHandler(TokenValidationFailException.class)
+	public ApiResponse<Void> handleTokenValidationFailException(TokenValidationFailException e) {
+		log.debug(e.getMessage(), e.fillInStackTrace());
+
+		return ApiResponse.error(UNAUTHORIZED, e.getMessage());
 	}
 
 	@ResponseStatus(NOT_FOUND)

--- a/goldblin-auth/src/main/resources/application-example.yml
+++ b/goldblin-auth/src/main/resources/application-example.yml
@@ -13,6 +13,12 @@ spring:
     hibernate:
       ddl-auto: validate
 
+jwt:
+  issuer: ${JWT_ISSUER}
+  secret-key: ${JWT_SECRET_KEY}
+  expired-after: 60 # 60분
+  refresh-expired-after: 10080 # 7일 (7*24*60)
+
 springdoc:
   default-consumes-media-type: application/json
   default-produces-media-type: application/json

--- a/goldblin-auth/src/test/resources/application.yml
+++ b/goldblin-auth/src/test/resources/application.yml
@@ -8,3 +8,9 @@ spring:
     show-sql: true
     hibernate:
       ddl-auto: create-drop
+
+jwt:
+  issuer: test
+  secret-key: 7Jik7KaIIOy3qOu9gCDqsIDspojslYQh
+  expired-after: 60 # 60분
+  refresh-expired-after: 10080 # 7일 (7*24*60)


### PR DESCRIPTION
## 📎 관련 이슈
<!--이슈 태스크를 모두 완료하고 닫는다면 Resolves #번호-->
<!--이슈 태스크를 모두 완료하지는 못 했지만 닫는다면 Closes #번호-->
<!--이슈 태스크를 일부 완료하고 열어둔다면 Fixes #번호-->
Resolves #5 

## 📌 구현 내용
<!--빠른 리뷰를 위해 이해를 도울 만한 설명이 있다면 적어주세요!-->
- [x] `JwtManager` 생성 (토큰 생성, 토큰 관리, 파싱 등의 역할을 담당)
- [x] 로그인 기능구현

## 📝 고민한 점
- 확장성을 위한 Refresh Token 테이블 분리
